### PR TITLE
fix(dlsp): plan loader

### DIFF
--- a/small-repro/plan/plan.go
+++ b/small-repro/plan/plan.go
@@ -34,16 +34,16 @@ type Plan struct {
 
 // New load a new cue value
 func New(root, file string) (*Plan, error) {
-	k := Directory
-	i, err := loader.Dir(root, file)
+	k := File
+	i, err := loader.File(root, file)
 
 	if err != nil {
-		i, err = loader.File(root, file)
+		i, err = loader.Dir(root, file)
 		if err != nil {
 			return nil, err
 		}
 
-		k = File
+		k = Directory
 	}
 
 	v, err := i.GetValue()

--- a/small-repro/workspace/workspace.go
+++ b/small-repro/workspace/workspace.go
@@ -61,7 +61,7 @@ func (wk *Workspace) GetPlan(file string) (*plan.Plan, error) {
 	file = wk.trimRootPath(file)
 
 	for _, p := range wk.plans {
-		wk.log.Debugf("compare %s with %s", p.File(), file)
+		wk.log.Debugf("compare %s %s with %s", p.Kind(), p.File(), file)
 		if p.Kind() == plan.File && p.File() == file {
 			return p, nil
 		}


### PR DESCRIPTION
To make sure that a single plan file is loaded, `plan.New` has been rework to
invert loading process, it will first try as a file and then as a directory.

This way, if the loaded file include an external definition from another file,
it will load it as a directory.
The issue was that it was possible to load multiple plan as a directory because
they were merged into a single one.

Resolves: https://github.com/grouville/dagger-lsp/issues/10
Depends on: #9 
Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>