### PR TITLE
kind/improve: fix multiline string parsing

### DIFF
--- a/semantic/tokenize.go
+++ b/semantic/tokenize.go
@@ -30,6 +30,9 @@ func initScanner(URI string, log logging.Logger) (*sitter.Node, *Scanner, error)
 		startCol:  0,
 		code:      code,
 		logger:    log,
+		endLine:   0,
+		endCol:    0,
+		nodeType:  NodeType(OTHER),
 	}, nil
 }
 

--- a/semantic/utils.go
+++ b/semantic/utils.go
@@ -3,6 +3,7 @@ package semantic
 import (
 	"io/ioutil"
 	"math"
+	"strings"
 
 	protocol "github.com/tliron/glsp/protocol_3_16"
 	"github.com/tliron/kutil/logging"
@@ -68,4 +69,9 @@ func readFile(filename string, logger logging.Logger) ([]byte, error) {
 		return nil, err
 	}
 	return data, nil
+}
+
+// Checks whether a token is a is multiline string
+func isMultilineStringToken(node string) bool {
+	return strings.HasPrefix(node, "(multiline_string_lit")
 }


### PR DESCRIPTION
Consider multiline strings as just strings, don't manage string interpolation for now. Avoids breaking the coloring. Temporary until parsing fix

Signed-off-by: guillaume