### PR TITLE
Fix version level

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -24,7 +24,7 @@ type LSP struct {
 
 const (
 	Name    = "cuelsp"
-	Version = "0.3.4"
+	Version = "0.3.3"
 )
 
 // New initializes a new language protocol server that contains his logger


### PR DESCRIPTION
Fix version level to correct one: `0.3.3`. The LSP versioning logged when being run was in advance with the git release version. Revert internal lsp version to previous one, so that the git version gets synced

Signed-off-by: Guillaume de Rouville <31691250+grouville@users.noreply.github.com>