### PR TITLE
Fix goreleaser build path

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,7 @@
 project_name: cuelsp
 
 builds:
+  - main: ./cmd/cuelsp/
   - id: darwin-amd64
     env:
       - CGO_ENABLED=1


### PR DESCRIPTION
Between the latest lsp release and this one, the build path has been changed (PR #71 and #74).

Signed-off-by: guillaume