### PR TITLE
fix(hover): primitive type displayed wrong

### DIFF
--- a/internal/docValue.go
+++ b/internal/docValue.go
@@ -56,8 +56,10 @@ func customerFormatNode(node ast.Node, depth int) string {
 			return formatNode(n)
 		case *ast.StructLit:
 			return fmt.Sprintf("%s: %s", n.Label, formatNode(v))
+		case *ast.BasicLit:
+			return fmt.Sprintf("%s: %s", n.Label, formatNode(v))
 		default:
-			doc += fmt.Sprintf("%s: {TEST\n%s}", n.Label, customerFormatNode(v, depth+1))
+			doc += fmt.Sprintf("%s: {\n%s}", n.Label, customerFormatNode(v, depth+1))
 		}
 	case *ast.StructLit:
 		for _, d := range n.Elts {


### PR DESCRIPTION
There was an issue on hover for type `#test: "bar"`, it wasn't displaying it
correctly because it considered them as `*ast.Field` when it was in reality a
`*ast.BasicLit`.

This PR adds a case in `customerFormatNode` to fix this issue.

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>