### PR TITLE
Support import aliases

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -19,6 +19,10 @@ type File struct {
 
 	// Definitions of the file
 	defs *parser.Definitions
+
+	// Package aliases of the file
+	// Maps alias to import path
+	importAliases map[string]string
 }
 
 // New create a File and analise CUE ast in it.
@@ -29,13 +33,23 @@ func New(path string) (*File, error) {
 	}
 
 	defs := parser.Definitions{}
-	parser.ParseDefs(&defs, content)
+	importAliases := make(map[string]string)
+	parser.ParseDefs(&defs, importAliases, content)
 
 	return &File{
-		path:    path,
-		content: content,
-		defs:    &defs,
+		path:          path,
+		content:       content,
+		defs:          &defs,
+		importAliases: importAliases,
 	}, nil
+}
+
+// AliasImportPath returns the import path of some package alias.
+func (f *File) AliasImportPath(alias string) (string, bool) {
+	if importPath, ok := f.importAliases[alias]; ok {
+		return importPath, true
+	}
+	return "", false
 }
 
 func (f *File) String() string {

--- a/parser/definition_test.go
+++ b/parser/definition_test.go
@@ -116,7 +116,8 @@ func TestDefinitionParsing(t *testing.T) {
 			}
 
 			defs := Definitions{}
-			ParseDefs(&defs, f)
+			importAliases := make(map[string]string)
+			ParseDefs(&defs, importAliases, f)
 			output := defs.String()
 			for _, o := range tc.output {
 				require.Contains(t, output, o)
@@ -177,7 +178,8 @@ func TestFindDefinition(t *testing.T) {
 			}
 
 			defs := Definitions{}
-			ParseDefs(&defs, f)
+			importAliases := make(map[string]string)
+			ParseDefs(&defs, importAliases, f)
 
 			name, err := defs.Find(tc.input.line, tc.input.col)
 			if err != nil {

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -52,7 +52,8 @@ func TestNew(t *testing.T) {
 				RootFilePath: "main.cue",
 				Kind:         File,
 				imports: map[string]*loader.Instance{
-					"test": nil,
+					"test":  nil,
+					"test2": nil,
 				},
 			},
 		},
@@ -176,22 +177,22 @@ func TestPlan_GetDefinition(t *testing.T) {
 			defs: []Def{
 				{
 					path: "_#TestName",
-					line: 7,
+					line: 8,
 					char: 1,
 				},
 				{
 					path: "#Test",
-					line: 9,
+					line: 10,
 					char: 9,
 				},
 				{
 					path: "_#TestName",
-					line: 15,
+					line: 16,
 					char: 12,
 				},
 				{
 					path: "#Test",
-					line: 14,
+					line: 15,
 					char: 15,
 				},
 			},
@@ -365,19 +366,19 @@ func TestPlan_GetInstance(t *testing.T) {
 			file: "main.cue",
 			defs: []Def{
 				{
-					line: 7,
+					line: 8,
 					char: 1,
 				},
 				{
-					line: 9,
+					line: 10,
 					char: 9,
 				},
 				{
-					line: 15,
+					line: 16,
 					char: 12,
 				},
 				{
-					line: 14,
+					line: 15,
 					char: 15,
 				},
 			},
@@ -500,7 +501,8 @@ func TestPlan_Reload(t *testing.T) {
 				RootFilePath: "main.cue",
 				Kind:         File,
 				imports: map[string]*loader.Instance{
-					"test": nil,
+					"test":  nil,
+					"test2": nil,
 				},
 			},
 		},

--- a/plan/testdata/with-cue-mod/cue.mod/pkg/test.com/test2/test2.cue
+++ b/plan/testdata/with-cue-mod/cue.mod/pkg/test.com/test2/test2.cue
@@ -1,0 +1,7 @@
+package test2
+
+#Test: {
+	name: string
+
+	assert: string
+}

--- a/plan/testdata/with-cue-mod/main.cue
+++ b/plan/testdata/with-cue-mod/main.cue
@@ -2,6 +2,7 @@ package main
 
 import (
 	"test.com/test"
+	t "test.com/test2"
 )
 
 _#TestName: =~"test"
@@ -11,7 +12,7 @@ test1: test.#Test & {
 	assert: "it's the first test"
 }
 
-test2: test.#Test & {
+test2: t.#Test & {
 	name:   _#TestName & "test 2"
 	assert: "it's the second test"
 }


### PR DESCRIPTION
It doesn't seem possible to get package aliases from cue's build
instances. They only seem to be used internally in the adt and not
exported in the public API.

Therefore the patch relies on the ast to record package aliases by
loaded file. When the selector of a definition isn't found we make some
extra calls to see if it's a package alias in the current file and find
the associated instance.

Closes #79